### PR TITLE
Constrain container-fluid max-width on large screens

### DIFF
--- a/themes/union_custom/css/layout/layout.css
+++ b/themes/union_custom/css/layout/layout.css
@@ -1,0 +1,12 @@
+/**
+ * @file
+ * Layout overrides for Union Custom theme
+ */
+
+/* Make container-fluid follow the same width as container for screens with width over 1500px */
+
+@media (min-width: 1500px) {
+  .container-fluid {
+    max-width: 1440px;
+  }
+}


### PR DESCRIPTION
The idea is to make the website easier to read. But please test the CSS before merging, I'm doing this blindly without running the site locally.

Before:
<img width="2672" height="1521" alt="image" src="https://github.com/user-attachments/assets/a64164c8-a040-4399-9bf3-cc181da2f791" />
After:
<img width="2672" height="1521" alt="image" src="https://github.com/user-attachments/assets/0a028ed0-50cc-4751-8907-f90ff4b487aa" />
